### PR TITLE
feat: add locale switch for svelte migration

### DIFF
--- a/lda-front/src/app.css
+++ b/lda-front/src/app.css
@@ -54,7 +54,7 @@ img {
 .page-shell {
   width: min(calc(100% - 2rem), var(--content));
   margin: 0 auto;
-  padding: 1.25rem 0 3.5rem;
+  padding: 1rem 0 3rem;
 }
 
 .topbar {
@@ -63,11 +63,11 @@ img {
   z-index: 30;
   display: grid;
   grid-template-columns: 1fr auto auto;
-  gap: 1rem;
+  gap: 0.85rem;
   align-items: center;
   width: 100%;
-  margin-bottom: 4rem;
-  padding: 0.9rem 1rem;
+  margin-bottom: 2.25rem;
+  padding: 0.62rem 0.8rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 999px;
   background: rgba(10, 10, 11, 0.76);
@@ -85,13 +85,13 @@ img {
 .brand-mark {
   display: inline-grid;
   place-items: center;
-  width: 2.5rem;
-  height: 2.5rem;
+  width: 2.35rem;
+  height: 2.35rem;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 0.65rem;
   color: var(--accent);
   font-family: 'Geist Mono', ui-monospace, monospace;
-  font-size: 0.78rem;
+  font-size: 0.72rem;
   letter-spacing: 0.08em;
 }
 
@@ -117,17 +117,17 @@ footer p {
 }
 
 .eyebrow {
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.45rem;
   color: var(--fg-3);
-  font-size: 0.72rem;
+  font-size: 0.68rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
 .pill-nav {
   display: inline-flex;
-  gap: 0.45rem;
-  padding: 0.25rem;
+  gap: 0.4rem;
+  padding: 0.2rem;
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.02);
@@ -139,10 +139,10 @@ footer p {
 }
 
 .pill-nav a {
-  padding: 0.55rem 0.9rem;
+  padding: 0.48rem 0.78rem;
   border-radius: 999px;
   color: var(--fg-2);
-  font-size: 0.88rem;
+  font-size: 0.8rem;
 }
 
 .pill-nav a:hover,
@@ -153,20 +153,20 @@ footer p {
 }
 
 .locale-badge {
-  padding: 0.55rem 0.8rem;
+  padding: 0.48rem 0.75rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 999px;
   color: var(--accent);
-  font-size: 0.74rem;
+  font-size: 0.68rem;
   letter-spacing: 0.08em;
 }
 
 .hero {
   display: grid;
   grid-template-columns: minmax(0, 1.2fr) minmax(280px, 0.8fr);
-  gap: 2rem;
+  gap: 1.6rem;
   align-items: start;
-  padding: 1rem 0 2.5rem;
+  padding: 0.75rem 0 2.15rem;
 }
 
 .hero-copy {
@@ -181,36 +181,37 @@ h3,
 }
 
 h1 {
-  font-size: clamp(3rem, 8vw, 6rem);
+  font-size: clamp(2.7rem, 7vw, 4.8rem);
   font-weight: 300;
   line-height: 0.98;
-  letter-spacing: -0.04em;
+  letter-spacing: -0.05em;
 }
 
 h2 {
-  font-size: clamp(1.7rem, 3vw, 2.55rem);
-  font-weight: 300;
-  line-height: 1.05;
+  font-size: clamp(1.4rem, 2.5vw, 2rem);
+  font-weight: 350;
+  line-height: 1.08;
   letter-spacing: -0.03em;
 }
 
 h3 {
-  font-size: 1.15rem;
+  font-size: 1.02rem;
   font-weight: 500;
-  line-height: 1.2;
+  line-height: 1.22;
 }
 
 .lead {
-  margin-top: 1.3rem;
+  margin-top: 1.1rem;
   max-width: 34rem;
   color: var(--fg);
-  font-size: 1.15rem;
+  font-size: 1rem;
 }
 
 .body {
-  margin-top: 1rem;
+  margin-top: 0.9rem;
   max-width: 34rem;
   color: var(--fg-2);
+  font-size: 0.96rem;
 }
 
 .hero-actions {
@@ -410,7 +411,132 @@ footer {
 
 footer p {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: 0.84rem;
+}
+
+.section-heading-wide {
+  max-width: var(--prose);
+}
+
+.post-grid,
+.archive-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.post-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.archive-list {
+  grid-template-columns: 1fr;
+  max-width: 54rem;
+}
+
+.post-card,
+.archive-item {
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.02);
+  padding: 1.1rem;
+}
+
+.post-meta {
+  margin: 0 0 0.75rem;
+  color: var(--accent-2);
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.post-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.9rem;
+}
+
+.post-tags span {
+  padding: 0.34rem 0.56rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--fg-3);
+  font-family: 'Geist Mono', ui-monospace, monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.post-link,
+.archive-link {
+  display: inline-flex;
+  width: fit-content;
+  margin-top: 1rem;
+  color: var(--accent);
+  font-size: 0.86rem;
+}
+
+.archive-title,
+.article-title {
+  max-width: 18ch;
+}
+
+.article-shell {
+  max-width: 62rem;
+  padding: 1.2rem;
+  box-shadow: var(--shadow);
+}
+
+.article-title {
+  margin-top: 0.35rem;
+  font-size: clamp(2.2rem, 5vw, 3.8rem);
+  font-weight: 300;
+  line-height: 1;
+  letter-spacing: -0.05em;
+}
+
+.article-excerpt {
+  max-width: 42rem;
+  margin-top: 1rem;
+  font-size: 0.98rem;
+  color: var(--fg);
+}
+
+.article-cover {
+  width: 100%;
+  margin-top: 1.2rem;
+  border-radius: 0.85rem;
+  border: 1px solid var(--line);
+}
+
+.article-body {
+  display: grid;
+  gap: 1.25rem;
+  margin-top: 1.35rem;
+}
+
+.article-section {
+  padding-top: 1.1rem;
+  border-top: 1px solid var(--line);
+}
+
+.article-section h2 {
+  margin-bottom: 0.6rem;
+  font-size: clamp(1.2rem, 2vw, 1.55rem);
+  font-weight: 400;
+}
+
+.article-section p,
+.article-section li {
+  max-width: var(--prose);
+  font-size: 0.96rem;
+}
+
+.article-section ul {
+  margin: 0.8rem 0 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.45rem;
 }
 
 @keyframes float-in {

--- a/lda-front/src/lib/AltchaWidget.svelte
+++ b/lda-front/src/lib/AltchaWidget.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { createAltchaStore } from './altchaStore';
+
+  interface Props {
+    challengeurl?: string;
+    onstatechange?: (payload: string | null) => void;
+    ui: {
+      altchaIdle: string;
+      altchaLoading: string;
+      altchaVerified: string;
+      altchaError: string;
+      altchaAria: string;
+    };
+  }
+
+  let { challengeurl = '/api/altcha-challenge', onstatechange, ui }: Props = $props();
+
+  let altchaState = $state<'idle' | 'loading' | 'verified' | 'error'>('idle');
+  let errorText = $state<string | null>(null);
+  let payload = $state<string | null>(null);
+  let verify = async () => {};
+  let cleanup = () => {};
+
+  $effect(() => {
+    cleanup();
+
+    const store = createAltchaStore(challengeurl);
+    const unsubscribeState = store.altchaState.subscribe((value) => {
+      altchaState = value;
+    });
+    const unsubscribeError = store.errorText.subscribe((value) => {
+      errorText = value;
+    });
+    const unsubscribePayload = store.payload.subscribe((value) => {
+      payload = value;
+      onstatechange?.(value);
+    });
+
+    verify = store.verify;
+    cleanup = () => {
+      unsubscribeState();
+      unsubscribeError();
+      unsubscribePayload();
+    };
+
+    return cleanup;
+  });
+
+  onDestroy(() => cleanup());
+</script>
+
+<button type="button" class="altcha-box" disabled={altchaState === 'loading'} onclick={() => verify()} aria-label={ui.altchaAria}>
+  <span class="checkbox" class:checked={altchaState === 'verified'}>
+    {#if altchaState === 'loading'}
+      <span class="spinner"></span>
+    {:else if altchaState === 'verified'}
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
+        <polyline points="20 6 9 17 4 12" />
+      </svg>
+    {/if}
+  </span>
+  <span class="label">
+    {#if altchaState === 'verified'}
+      {ui.altchaVerified}
+    {:else if altchaState === 'loading'}
+      {ui.altchaLoading}
+    {:else if altchaState === 'error'}
+      {errorText ?? ui.altchaError}
+    {:else}
+      {ui.altchaIdle}
+    {/if}
+  </span>
+</button>
+
+<style>
+  .altcha-box {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.75rem 0.9rem;
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid var(--line);
+    border-radius: 0.6rem;
+    color: var(--fg-2);
+    font-size: 0.84rem;
+    cursor: pointer;
+  }
+
+  .altcha-box:disabled {
+    cursor: wait;
+  }
+
+  .checkbox {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1rem;
+    height: 1rem;
+    border: 1px solid var(--line-strong);
+    border-radius: 0.25rem;
+  }
+
+  .checkbox.checked {
+    border-color: var(--accent);
+    background: var(--accent);
+    color: #0a0a0b;
+  }
+
+  .checkbox svg {
+    width: 0.7rem;
+    height: 0.7rem;
+  }
+
+  .spinner {
+    width: 0.7rem;
+    height: 0.7rem;
+    border: 2px solid rgba(255, 255, 255, 0.18);
+    border-top-color: var(--accent);
+    border-radius: 999px;
+    animation: spin 0.8s linear infinite;
+  }
+
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+</style>

--- a/lda-front/src/lib/ContactForm.svelte
+++ b/lda-front/src/lib/ContactForm.svelte
@@ -1,0 +1,286 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import AltchaWidget from './AltchaWidget.svelte';
+  import { getCommsBaseUrl } from './comms';
+  import type { HomeCopy } from './content';
+
+  type Status = 'idle' | 'submitting' | 'success' | 'error';
+
+  export let labels: HomeCopy['contact']['form'];
+  export let ui: HomeCopy['ui'];
+  export let locale: HomeCopy['locale'];
+  export let title: string;
+  export let note: string;
+
+  let name = '';
+  let email = '';
+  let phone = '';
+  let message = '';
+  let whatsappOptIn = false;
+  let website = '';
+  let status: Status = 'idle';
+  let errorText = '';
+  let altchaPayload: string | null = null;
+  let commsBase = '';
+  let challengeUrl = '/api/altcha-challenge';
+
+  onMount(() => {
+    commsBase = getCommsBaseUrl();
+    challengeUrl = commsBase ? `${commsBase}/api/altcha-challenge` : '/api/altcha-challenge';
+  });
+
+  async function handleSubmit(event: SubmitEvent) {
+    event.preventDefault();
+
+    if (!altchaPayload) {
+      status = 'error';
+      errorText = 'Verify the anti-abuse challenge first.';
+      return;
+    }
+
+    status = 'submitting';
+    errorText = '';
+
+    try {
+      const res = await fetch(`${commsBase}/api/contact`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          name,
+          email: email || '',
+          phone: phone || undefined,
+          message,
+          whatsapp_opt_in: whatsappOptIn,
+          source: 'site',
+          language: locale,
+          altcha: altchaPayload,
+          website
+        })
+      });
+
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+
+      status = 'success';
+      name = '';
+      email = '';
+      phone = '';
+      message = '';
+      whatsappOptIn = false;
+      website = '';
+      altchaPayload = null;
+    } catch {
+      status = 'error';
+      errorText = labels.error;
+    }
+  }
+</script>
+
+<section class="contact-shell">
+  <div class="contact-copy">
+    <p class="eyebrow">{title}</p>
+    <h3>{note}</h3>
+    <p>{labels.submit}</p>
+    <p class="note">{ui.altchaPrompt}</p>
+  </div>
+
+  {#if status === 'success'}
+    <div class="form-card form-success">
+      <p>{labels.success}</p>
+      <button type="button" class="ghost" on:click={() => (status = 'idle')}>{ui.sendAnother}</button>
+    </div>
+  {:else}
+    <form class="form-card" on:submit|preventDefault={handleSubmit}>
+      <input class="honeypot" aria-hidden="true" tabindex="-1" autocomplete="off" bind:value={website} />
+
+      <div class="row">
+        <label>
+          <span>{labels.name}</span>
+          <input bind:value={name} placeholder={labels.namePlaceholder} required />
+        </label>
+        <label>
+          <span>{labels.email}</span>
+          <input bind:value={email} placeholder={labels.emailPlaceholder} />
+        </label>
+      </div>
+
+      <label>
+        <span>{labels.phone}</span>
+        <input bind:value={phone} placeholder={labels.phonePlaceholder} />
+      </label>
+
+      <label>
+        <span>{labels.message}</span>
+        <textarea bind:value={message} placeholder={labels.messagePlaceholder} rows="5" required></textarea>
+      </label>
+
+      <label class="checkbox-row">
+        <input type="checkbox" bind:checked={whatsappOptIn} />
+        <span>{labels.whatsappOptIn}</span>
+      </label>
+
+      <div class="challenge-row">
+        <AltchaWidget challengeurl={challengeUrl} ui={ui} onstatechange={(payload) => (altchaPayload = payload)} />
+        <p>{labels.submit}</p>
+      </div>
+
+      {#if status === 'error'}
+        <p class="error" role="alert">{errorText}</p>
+      {/if}
+
+      <button class="submit" type="submit" disabled={status === 'submitting'}>
+        {status === 'submitting' ? labels.submitting : labels.submit}
+      </button>
+    </form>
+  {/if}
+</section>
+
+<style>
+  .contact-shell {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .contact-copy {
+    max-width: 42rem;
+  }
+
+  .contact-copy h3 {
+    margin: 0.35rem 0 0.55rem;
+    font-size: clamp(1.05rem, 1.8vw, 1.35rem);
+    font-weight: 400;
+    line-height: 1.3;
+    color: var(--fg);
+  }
+
+  .contact-copy p {
+    margin: 0;
+    color: var(--fg-2);
+    max-width: 38rem;
+  }
+
+  .contact-copy .note {
+    margin-top: 0.75rem;
+    color: var(--fg-3);
+    font-size: 0.8rem;
+  }
+
+  .form-card {
+    display: grid;
+    gap: 0.9rem;
+    padding: 1rem;
+    border: 1px solid var(--line);
+    border-radius: 0.95rem;
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .form-success {
+    align-items: start;
+  }
+
+  .row {
+    display: grid;
+    gap: 0.9rem;
+  }
+
+  label {
+    display: grid;
+    gap: 0.35rem;
+    color: var(--fg-2);
+    font-size: 0.84rem;
+  }
+
+  input,
+  textarea {
+    width: 100%;
+    border: 1px solid var(--line);
+    border-radius: 0.6rem;
+    background: rgba(255, 255, 255, 0.02);
+    color: var(--fg);
+    padding: 0.8rem 0.9rem;
+    font: inherit;
+  }
+
+  input::placeholder,
+  textarea::placeholder {
+    color: var(--fg-3);
+  }
+
+  input:focus,
+  textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+  }
+
+  .checkbox-row {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+
+  .checkbox-row input {
+    width: 1rem;
+    height: 1rem;
+    padding: 0;
+    accent-color: var(--accent);
+  }
+
+  .challenge-row {
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .challenge-row p {
+    margin: 0;
+    color: var(--fg-3);
+    font-size: 0.8rem;
+  }
+
+  .submit,
+  .ghost {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: fit-content;
+    min-height: 2.55rem;
+    padding: 0.68rem 0.95rem;
+    border-radius: 0.55rem;
+    border: 1px solid var(--line);
+    background: rgba(255, 255, 255, 0.02);
+    color: var(--fg);
+    font-size: 0.82rem;
+  }
+
+  .submit:hover,
+  .ghost:hover {
+    border-color: var(--accent);
+  }
+
+  .submit:disabled {
+    opacity: 0.55;
+    cursor: wait;
+  }
+
+  .error {
+    margin: 0;
+    color: #d58a8a;
+    font-size: 0.82rem;
+  }
+
+  .honeypot {
+    position: absolute;
+    left: -9999px;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+  }
+
+  @media (min-width: 768px) {
+    .row {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+</style>

--- a/lda-front/src/lib/LocaleSwitch.svelte
+++ b/lda-front/src/lib/LocaleSwitch.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import type { HomeCopy } from './content';
+
+  export let locale: HomeCopy['locale'];
+  export let href: string;
+  export let label: string;
+
+  const target = locale === 'en' ? 'PT-BR' : 'EN';
+  const ariaLabel = locale === 'en' ? 'Switch to Portuguese' : 'Switch to English';
+</script>
+
+<a class="locale-switch" href={href} aria-label={ariaLabel} title={ariaLabel}>
+  <span class="switch-label">{label}</span>
+  <span class="switch-target">{target}</span>
+</a>
+
+<style>
+  .locale-switch {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.48rem 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 999px;
+    color: var(--accent);
+    font-family: 'Geist Mono', ui-monospace, monospace;
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .locale-switch:hover,
+  .locale-switch:focus-visible {
+    border-color: var(--accent);
+    outline: none;
+  }
+
+  .switch-label {
+    color: var(--fg-3);
+  }
+
+  .switch-target {
+    color: var(--accent);
+  }
+</style>

--- a/lda-front/src/lib/altchaStore.ts
+++ b/lda-front/src/lib/altchaStore.ts
@@ -1,0 +1,80 @@
+import { get, writable } from 'svelte/store';
+
+export type AltchaState = 'idle' | 'loading' | 'verified' | 'error';
+
+type Challenge = {
+  algorithm: string;
+  challenge: string;
+  salt: string;
+  maxNumber: number;
+  signature: string;
+};
+
+export function createAltchaStore(challengeurl: string) {
+  const state = writable<AltchaState>('idle');
+  const errorText = writable<string | null>(null);
+  const payload = writable<string | null>(null);
+
+  async function sha256(message: string): Promise<string> {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(message);
+    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map((byte) => byte.toString(16).padStart(2, '0')).join('');
+  }
+
+  async function solveChallenge(challenge: string, salt: string, maxNumber: number): Promise<number | null> {
+    for (let i = 0; i <= maxNumber; i += 1) {
+      const hash = await sha256(`${salt}${i}`);
+      if (hash === challenge) return i;
+    }
+    return null;
+  }
+
+  async function verify() {
+    const current = get(state);
+    if (current === 'verified' || current === 'loading') return;
+
+    state.set('loading');
+    errorText.set(null);
+    payload.set(null);
+
+    try {
+      const res = await fetch(challengeurl, { credentials: 'same-origin' });
+      if (!res.ok) throw new Error('Failed to load challenge');
+      const data: Challenge = await res.json();
+      const number = await solveChallenge(data.challenge, data.salt, data.maxNumber);
+      if (number === null) throw new Error('Could not solve challenge');
+
+      payload.set(
+        JSON.stringify({
+          algorithm: data.algorithm,
+          challenge: data.challenge,
+          number,
+          salt: data.salt,
+          signature: data.signature,
+        })
+      );
+      state.set('verified');
+    } catch (err) {
+      state.set('error');
+      errorText.set(err instanceof Error ? err.message : 'Verification failed');
+      payload.set(null);
+    }
+  }
+
+  function reset() {
+    state.set('idle');
+    errorText.set(null);
+    payload.set(null);
+  }
+
+  return {
+    altchaState: { subscribe: state.subscribe },
+    errorText: { subscribe: errorText.subscribe },
+    payload: { subscribe: payload.subscribe },
+    verify,
+    reset,
+    getValue: () => get(payload),
+  };
+}

--- a/lda-front/src/lib/comms.ts
+++ b/lda-front/src/lib/comms.ts
@@ -1,0 +1,15 @@
+export function getCommsBaseUrl(): string {
+  if (typeof window === 'undefined') return '';
+
+  const host = window.location.host;
+
+  if (host.includes('rbxsystems.ch')) {
+    return 'https://api.comms.rbxsystems.ch';
+  }
+
+  if (host.includes('rbx.ia.br')) {
+    return 'https://api.comms.rbx.ia.br';
+  }
+
+  return import.meta.env?.VITE_COMMS_BASE_URL ?? 'http://localhost:8080';
+}

--- a/lda-front/src/lib/content.ts
+++ b/lda-front/src/lib/content.ts
@@ -1,0 +1,479 @@
+export type Locale = 'pt-BR' | 'en';
+
+export type BlogSection = {
+  heading: string;
+  paragraphs: string[];
+  bullets?: string[];
+};
+
+export type BlogPost = {
+  slug: string;
+  date: string;
+  readTime: string;
+  tags: string[];
+  title: string;
+  excerpt: string;
+  cover?: string;
+  sections: BlogSection[];
+};
+
+export type HomeCopy = {
+  locale: Locale;
+  htmlLang: string;
+  nav: {
+    work: string;
+    writing: string;
+    contact: string;
+  };
+  hero: {
+    eyebrow: string;
+    title: string;
+    lead: string;
+    body: string;
+    location: string;
+    status: string;
+  };
+  intro: {
+    eyebrow: string;
+    title: string;
+    body: string;
+  };
+  work: {
+    eyebrow: string;
+    title: string;
+    items: Array<{
+      title: string;
+      body: string;
+      meta: string;
+    }>;
+  };
+  writing: {
+    eyebrow: string;
+    title: string;
+    body: string;
+  };
+  contact: {
+    eyebrow: string;
+    title: string;
+    body: string;
+    note: string;
+    form: {
+      name: string;
+      email: string;
+      phone: string;
+      message: string;
+      whatsappOptIn: string;
+      submit: string;
+      submitting: string;
+      success: string;
+      error: string;
+      namePlaceholder: string;
+      emailPlaceholder: string;
+      phonePlaceholder: string;
+      messagePlaceholder: string;
+    };
+  };
+  ui: {
+    archive: string;
+    home: string;
+    readArticle: string;
+    viewFullArchive: string;
+    sendAnother: string;
+    switchLocale: string;
+    altchaIdle: string;
+    altchaLoading: string;
+    altchaVerified: string;
+    altchaError: string;
+    altchaPrompt: string;
+    altchaAria: string;
+  };
+  footer: string;
+};
+
+const BLOG_POSTS: Record<Locale, BlogPost[]> = {
+  'pt-BR': [
+    {
+      slug: 'blog-como-projecao-editorial',
+      date: '2026-07-04',
+      readTime: '4 min',
+      tags: ['blog', 'editorial', 'arquitetura'],
+      title: 'Blog como projeção editorial, não como decoração',
+      excerpt:
+        'A parte que faltou na primeira migração não foi um card. Foi uma camada editorial: artigo, índice, data, leitura e páginas de detalhe que carregam contexto de forma estável.',
+      sections: [
+        {
+          heading: 'O problema com páginas genéricas',
+          paragraphs: [
+            'Um front institucional sem escrita vira uma vitrine curta. Ele mostra que existe, mas não explica como pensa. Para este site, o blog precisa carregar argumento, não apenas anúncio.',
+            'O site anterior tinha essa vocação embutida em páginas e notas. Na migração inicial eu preservei a superfície, mas não a gramática de publicação.',
+          ],
+          bullets: [
+            'Índice com leitura, data e tags.',
+            'Página de detalhe com seções legíveis.',
+            'Histórico de escrita que sobreviva ao deploy.',
+          ],
+        },
+        {
+          heading: 'O que deveria ter entrado na migração',
+          paragraphs: [
+            'Eu deveria ter trazido um modelo de blog em vez de apenas um painel de vitrine. Isso inclui posts estruturados, página de arquivo, e navegação por tema.',
+            'A fidelidade não está no framework. Está no tipo de conteúdo que o site consegue sustentar sem virar ruído.',
+          ],
+        },
+        {
+          heading: 'O resultado desejado',
+          paragraphs: [
+            'O blog entra como uma camada de raciocínio público. Ele não compete com o portfólio. Ele explica as decisões por trás dele.',
+          ],
+        },
+      ],
+    },
+    {
+      slug: 'whatsapp-no-lugar-de-email',
+      date: '2026-07-04',
+      readTime: '5 min',
+      tags: ['contato', 'comms', 'whatsapp'],
+      title: 'Contato operacional via WhatsApp, sem email exposto',
+      excerpt:
+        'O formulário deve ser a única porta pública. O email não precisa aparecer como atalho de baixa fricção; o fluxo certo é o RBX comms, com entrega via WhatsApp e registro do lead.',
+      sections: [
+        {
+          heading: 'Por que esconder o email',
+          paragraphs: [
+            'Email fixo na tela vira um atalho frágil e pouco auditável. O usuário precisa de uma entrada clara; o operador precisa de roteamento, proteção anti-abuso e persistência.',
+            'O `rbx-comms` já nasceu para isso: `/api/contact` como porta pública, Altcha, honeypot, rate limit, persistência e entrega ao WhatsApp.',
+          ],
+        },
+        {
+          heading: 'O que a interface deve fazer',
+          paragraphs: [
+            'Expor um formulário curto, com nome, email ou telefone, mensagem e consentimento para WhatsApp quando aplicável. O resto fica do lado do serviço.',
+            'O frontend não deve decidir canal por conta própria. Ele só coleta, valida o básico e envia para o backend apropriado.',
+          ],
+          bullets: [
+            'Sem email fixo na página.',
+            'Sem CTA duplicado em vários lugares.',
+            'Sem mistura de contato e marketing.',
+          ],
+        },
+        {
+          heading: 'Fidelidade ao ecossistema',
+          paragraphs: [
+            'Isso alinha o site pessoal com o restante do ecossistema RBX: a interface apresenta, o serviço comunica e o operador acompanha.',
+          ],
+        },
+      ],
+    },
+    {
+      slug: 'tipografia-menor-menos-barulho',
+      date: '2026-07-04',
+      readTime: '4 min',
+      tags: ['design-system', 'tipografia', 'ui'],
+      title: 'Tipografia menor, superfície mais sutil',
+      excerpt:
+        'O SvelteKit ficou correto, mas o desenho inicial estava grande demais. O tom certo aqui é institucional e fino, com menos contraste gestual e mais controle de ritmo.',
+      sections: [
+        {
+          heading: 'O excesso da primeira versão',
+          paragraphs: [
+            'O primeiro corte foi mais alto e mais largo do que deveria. Em um site pessoal institucional, isso rouba sobriedade. O olho precisa de respiro, não de volume.',
+            'A solução é reduzir a escala, estreitar a largura de leitura e empurrar a força visual para a hierarquia, não para o tamanho.',
+          ],
+        },
+        {
+          heading: 'Como o design system ajuda',
+          paragraphs: [
+            'Textos mais contidos, labels mais discretos, bordas finas e cards que parecem documentos operacionais. É esse tipo de elegância que o site antigo carregava melhor.',
+            'A migração fica mais fiel quando a interface para de competir com a escrita.',
+          ],
+        },
+      ],
+    },
+  ],
+  en: [
+    {
+      slug: 'editorial-blog-not-just-decor',
+      date: '2026-07-04',
+      readTime: '4 min',
+      tags: ['blog', 'editorial', 'architecture'],
+      title: 'A blog as an editorial projection, not decoration',
+      excerpt:
+        'The missing part in the first migration was not another card. It was an editorial layer: article pages, an archive, dates, reading time and stable detail views.',
+      sections: [
+        {
+          heading: 'The problem with generic pages',
+          paragraphs: [
+            'An institutional site without writing becomes a short showcase. It proves the site exists, but it does not explain how it thinks. For this site, the blog must carry arguments, not just announcements.',
+            'The previous stack already hinted at that in notes and article pages. In the first migration I kept the surface, but not the publishing grammar.',
+          ],
+          bullets: [
+            'Archive with reading time, dates and tags.',
+            'Detail pages with readable sections.',
+            'Writing history that survives deploys.',
+          ],
+        },
+        {
+          heading: 'What should have come over',
+          paragraphs: [
+            'I should have brought a blog model instead of only a showcase panel. That means structured posts, an archive page and topic navigation.',
+            'Fidelity is not about the framework. It is about the kind of content the site can carry without becoming noise.',
+          ],
+        },
+        {
+          heading: 'The target result',
+          paragraphs: [
+            'The blog becomes a public reasoning layer. It does not compete with the portfolio. It explains the decisions behind it.',
+          ],
+        },
+      ],
+    },
+    {
+      slug: 'whatsapp-over-email',
+      date: '2026-07-04',
+      readTime: '5 min',
+      tags: ['contact', 'comms', 'whatsapp'],
+      title: 'Operational contact via WhatsApp, no pinned email',
+      excerpt:
+        'The form should be the only public door. Email does not need to sit on screen as a low-friction shortcut; the proper flow is RBX comms, with WhatsApp delivery and lead persistence.',
+      sections: [
+        {
+          heading: 'Why hide the email',
+          paragraphs: [
+            'A pinned email address is a fragile and weakly auditable shortcut. Users need one clear entry. Operators need routing, abuse protection and persistence.',
+            'That is what `rbx-comms` was built for: `/api/contact` as the public door, Altcha, honeypot, rate limiting, persistence and WhatsApp delivery.',
+          ],
+        },
+        {
+          heading: 'What the interface should do',
+          paragraphs: [
+            'Expose a short form with name, email or phone, message and WhatsApp consent where applicable. Everything else belongs to the service.',
+            'The frontend should not invent channel logic. It should only collect, validate the basics and send the request to the right backend.',
+          ],
+          bullets: [
+            'No email pinned on the page.',
+            'No duplicated CTA noise.',
+            'No blending of contact and marketing.',
+          ],
+        },
+        {
+          heading: 'Fit with the ecosystem',
+          paragraphs: [
+            'That keeps the personal site aligned with the RBX stack: the interface presents, the service communicates and the operator sees the result.',
+          ],
+        },
+      ],
+    },
+    {
+      slug: 'smaller-type-less-noise',
+      date: '2026-07-04',
+      readTime: '4 min',
+      tags: ['design-system', 'type', 'ui'],
+      title: 'Smaller type, quieter surface',
+      excerpt:
+        'The SvelteKit rewrite was correct, but the first pass was too large. The right tone here is institutional and restrained, with less gesture and more rhythm control.',
+      sections: [
+        {
+          heading: 'The first pass was too loud',
+          paragraphs: [
+            'The initial scale was taller and wider than it should have been. On an institutional personal site, that steals sobriety. The eye needs space, not volume.',
+            'The fix is to reduce scale, narrow the reading width and move visual force into hierarchy rather than size.',
+          ],
+        },
+        {
+          heading: 'How the design system helps',
+          paragraphs: [
+            'Smaller body text, quieter labels, thin borders and cards that feel like operational documents. That is the kind of elegance the old site handled better.',
+            'The migration becomes more faithful when the interface stops competing with the writing.',
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const HOME_COPY: Record<Locale, HomeCopy> = {
+  'pt-BR': {
+    locale: 'pt-BR',
+    htmlLang: 'pt-BR',
+    nav: {
+      work: 'Trabalho',
+      writing: 'Escrita',
+      contact: 'Contato',
+    },
+    hero: {
+      eyebrow: 'Engenharia autoral',
+      title: 'Leandro Damasio',
+      lead: 'Engenheiro de Computação. Sistemas de IA e interfaces para ambientes de alta confiabilidade.',
+      body: 'Constrói produtos digitais, plataformas de automação e sistemas operacionais com rigor institucional. O foco é confiabilidade, observabilidade e clareza operacional.',
+      location: 'Brasil · São Paulo / Zürich',
+      status: 'Disponível para projetos selecionados',
+    },
+    intro: {
+      eyebrow: 'Posicionamento',
+      title: 'Institucional, porém pessoal.',
+      body: 'O site precisa parecer um documento de trabalho, não um palco. Ele explica a prática, mostra o corpo de escrita e abre um canal de contato operacional sem ruído.',
+    },
+    work: {
+      eyebrow: 'Trabalho',
+      title: 'Sistemas, produtos e entrega',
+      items: [
+        {
+          title: 'RBX Systems',
+          body: 'Monorepo open-source de agentes de IA, agentes de código e ferramentas de nível de sistema.',
+          meta: 'Open source · arquitetura · maintainability',
+        },
+        {
+          title: 'Strategos',
+          body: 'Runtime estratégico para análise multicenário, decisão e rastreabilidade de premissas.',
+          meta: 'Decision support · situation room · governance',
+        },
+        {
+          title: 'x.sh',
+          body: 'Runtime de execução governada que transforma comandos reais em evidência causal durável.',
+          meta: 'Shell runtime · evidence · boundary control',
+        },
+      ],
+    },
+    writing: {
+      eyebrow: 'Escrita',
+      title: 'Blog e artigos',
+      body: 'A parte mais fiel da migração é a escrita estruturada. O blog abaixo traz argumento, data, leitura e detalhe, como um arquivo público de raciocínio.',
+    },
+    contact: {
+      eyebrow: 'Contato',
+      title: 'Um único formulário, sem email exposto',
+      body: 'Use o formulário para enviar a mensagem. O backend do `rbx-comms` faz o roteamento via WhatsApp e persiste o lead no fluxo correto.',
+      note: 'Sem email fixo na tela. Sem contato duplicado. Só a porta pública que o ecossistema já usa.',
+      form: {
+        name: 'Nome',
+        email: 'Email ou telefone',
+        phone: 'Telefone',
+        message: 'Mensagem',
+        whatsappOptIn: 'Pode responder por WhatsApp',
+        submit: 'Enviar via WhatsApp',
+        submitting: 'Enviando',
+        success: 'Mensagem enviada. O fluxo do RBX comms recebeu a solicitação.',
+        error: 'Não foi possível enviar agora. Tente novamente.',
+        namePlaceholder: 'Seu nome',
+        emailPlaceholder: 'email@dominio.com ou +55...',
+        phonePlaceholder: '+55 11 99999-9999',
+        messagePlaceholder: 'Explique brevemente o contexto, prazo e objetivo.',
+      },
+    },
+    ui: {
+      archive: 'Arquivo',
+      home: 'Início',
+      readArticle: 'Ler artigo',
+      viewFullArchive: 'Ver arquivo completo',
+      sendAnother: 'Enviar outra mensagem',
+      switchLocale: 'Idioma',
+      altchaIdle: "Não sou um robô",
+      altchaLoading: 'Verificando...',
+      altchaVerified: 'Verificado',
+      altchaError: 'Falha na verificação. Tente novamente.',
+      altchaPrompt: 'Altcha, honeypot e roteamento via RBX comms.',
+      altchaAria: 'Verificar desafio antiabuso',
+    },
+    footer: 'Leandro Damasio · Sistemas digitais com rigor institucional.',
+  },
+  en: {
+    locale: 'en',
+    htmlLang: 'en',
+    nav: {
+      work: 'Work',
+      writing: 'Writing',
+      contact: 'Contact',
+    },
+    hero: {
+      eyebrow: 'Authorial engineering',
+      title: 'Leandro Damasio',
+      lead: 'Computer Engineer. AI systems and interfaces for high-reliability environments.',
+      body: 'Builds digital products, automation platforms and operational systems with institutional rigor. The emphasis is reliability, observability and operational clarity.',
+      location: 'Brazil · São Paulo / Zürich',
+      status: 'Available for selected engagements',
+    },
+    intro: {
+      eyebrow: 'Positioning',
+      title: 'Institutional, but personal.',
+      body: 'The site should feel like a working document, not a stage. It explains the practice, surfaces a body of writing and opens an operational contact path without noise.',
+    },
+    work: {
+      eyebrow: 'Work',
+      title: 'Systems, products and delivery',
+      items: [
+        {
+          title: 'RBX Systems',
+          body: 'Open-source monorepo of AI agents, code agents and system-level tooling.',
+          meta: 'Open source · architecture · maintainability',
+        },
+        {
+          title: 'Strategos',
+          body: 'Strategic runtime for multi-scenario analysis, decision support and assumption traceability.',
+          meta: 'Decision support · situation room · governance',
+        },
+        {
+          title: 'x.sh',
+          body: 'Governed exec runtime that turns real commands into durable causal evidence.',
+          meta: 'Shell runtime · evidence · boundary control',
+        },
+      ],
+    },
+    writing: {
+      eyebrow: 'Writing',
+      title: 'Blog and essays',
+      body: 'The most faithful part of the migration is the structured writing layer. The archive below carries argument, date, reading time and detail, like a public record of reasoning.',
+    },
+    contact: {
+      eyebrow: 'Contact',
+      title: 'One form only, no pinned email',
+      body: 'Use the form to send the message. The `rbx-comms` backend routes it through WhatsApp and persists the lead in the proper flow.',
+      note: 'No fixed email on screen. No duplicated contact path. Just the public door the ecosystem already uses.',
+      form: {
+        name: 'Name',
+        email: 'Email or phone',
+        phone: 'Phone',
+        message: 'Message',
+        whatsappOptIn: 'Reply via WhatsApp',
+        submit: 'Send via WhatsApp',
+        submitting: 'Sending',
+        success: 'Message sent. RBX comms received the request.',
+        error: 'Could not send right now. Please try again.',
+        namePlaceholder: 'Your name',
+        emailPlaceholder: 'email@domain.com or +55...',
+        phonePlaceholder: '+55 11 99999-9999',
+        messagePlaceholder: 'Briefly explain the context, timing and goal.',
+      },
+    },
+    ui: {
+      archive: 'Archive',
+      home: 'Home',
+      readArticle: 'Read article',
+      viewFullArchive: 'View full archive',
+      sendAnother: 'Send another message',
+      switchLocale: 'Language',
+      altchaIdle: "I'm not a robot",
+      altchaLoading: 'Verifying...',
+      altchaVerified: 'Verified',
+      altchaError: 'Verification failed. Try again.',
+      altchaPrompt: 'Altcha, honeypot and routing via RBX comms.',
+      altchaAria: 'Verify anti-abuse challenge',
+    },
+    footer: 'Leandro Damasio · Digital systems with institutional rigor.',
+  },
+};
+
+export function resolveLocale(hostname: string): Locale {
+  return hostname.endsWith('.ch') ? 'en' : 'pt-BR';
+}
+
+export function getHomeCopy(locale: Locale): HomeCopy {
+  return HOME_COPY[locale];
+}
+
+export function getBlogPosts(locale: Locale): BlogPost[] {
+  return BLOG_POSTS[locale];
+}
+
+export function getBlogPost(locale: Locale, slug: string): BlogPost | undefined {
+  return BLOG_POSTS[locale].find((post) => post.slug === slug);
+}

--- a/lda-front/src/lib/locale.ts
+++ b/lda-front/src/lib/locale.ts
@@ -1,0 +1,15 @@
+export type Locale = 'pt-BR' | 'en';
+
+const LOCALE_ORIGINS: Record<Locale, string> = {
+  'pt-BR': 'https://leandrodamasio.rbx.ia.br',
+  en: 'https://leandrodamasio.rbxsystems.ch',
+};
+
+export function alternateLocale(locale: Locale): Locale {
+  return locale === 'en' ? 'pt-BR' : 'en';
+}
+
+export function getLocaleHref(locale: Locale, pathname: string): string {
+  const targetLocale = alternateLocale(locale);
+  return `${LOCALE_ORIGINS[targetLocale]}${pathname}`;
+}

--- a/lda-front/src/routes/+page.svelte
+++ b/lda-front/src/routes/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import type { PageData } from './$types';
+  import ContactForm from '$lib/ContactForm.svelte';
+  import LocaleSwitch from '$lib/LocaleSwitch.svelte';
 
   export let data: PageData;
 
@@ -10,13 +12,15 @@
 
   const anchors = [
     { href: '#work', label: data.copy.nav.work },
-    { href: '#practice', label: data.copy.nav.practice },
+    { href: '#writing', label: data.copy.nav.writing },
     { href: '#contact', label: data.copy.nav.contact },
   ];
+
+  $: featuredPosts = data.posts.slice(0, 3);
 </script>
 
 <svelte:head>
-  <title>{data.copy.hero.title} · {data.copy.hero.eyebrow}</title>
+  <title>{data.copy.hero.title}</title>
   <meta name="description" content={data.copy.hero.body} />
   <meta property="og:title" content={data.copy.hero.title} />
   <meta property="og:description" content={data.copy.hero.body} />
@@ -36,7 +40,7 @@
         <a href={anchor.href}>{anchor.label}</a>
       {/each}
     </nav>
-    <div class="locale-badge">{data.copy.locale.toUpperCase()}</div>
+    <LocaleSwitch locale={data.copy.locale} href={data.alternateHref} label={data.copy.ui.switchLocale} />
   </header>
 
   <main>
@@ -46,55 +50,37 @@
         <h1>{data.copy.hero.title}</h1>
         <p class="lead">{data.copy.hero.lead}</p>
         <p class="body">{data.copy.hero.body}</p>
-
         <div class="hero-actions">
-          <a class="button button-primary" href="#work">{data.copy.nav.work}</a>
+          <a class="button button-primary" href="#writing">{data.copy.nav.writing}</a>
           <a class="button button-secondary" href="#contact">{data.copy.nav.contact}</a>
         </div>
-
         <div class="meta-line">
           <span>{data.copy.hero.location}</span>
-          <span>{data.copy.hero.availability}</span>
+          <span>{data.copy.hero.status}</span>
         </div>
       </div>
 
-      <aside class="signal-panel" aria-label="Profile signals">
+      <aside class="signal-panel" aria-label="Positioning">
         <div>
-          <p class="eyebrow">Selected profile</p>
-          <h2>{data.copy.hero.status}</h2>
+          <p class="eyebrow">{data.copy.intro.eyebrow}</p>
+          <h2>{data.copy.intro.title}</h2>
         </div>
         <div class="signal-lines">
-          <span>{data.copy.hero.location}</span>
-          <span>Frontend · AI engineering · GitOps delivery</span>
-          <span>Operational interfaces for stable systems</span>
+          <span>{data.copy.intro.body}</span>
+          <span>{data.copy.writing.body}</span>
+          <span>{data.copy.contact.note}</span>
         </div>
       </aside>
     </section>
 
-    <section class="highlights" aria-label="Highlights">
-      {#each data.copy.highlights as item}
-        <div class="highlight-chip">{item}</div>
-      {/each}
-    </section>
-
-    <section id="practice" class="section-grid">
-      {#each data.copy.sections as section}
-        <article class="card">
-          <p class="eyebrow">{section.eyebrow}</p>
-          <h2>{section.title}</h2>
-          <p>{section.body}</p>
-        </article>
-      {/each}
-    </section>
-
     <section id="work" class="content-section">
       <div class="section-heading">
-        <p class="eyebrow">{data.copy.nav.work}</p>
-        <h2>{data.copy.hero.status}</h2>
+        <p class="eyebrow">{data.copy.work.eyebrow}</p>
+        <h2>{data.copy.work.title}</h2>
       </div>
 
       <div class="work-grid">
-        {#each data.copy.work as item}
+        {#each data.copy.work.items as item}
           <article class="work-card">
             <p class="work-meta">{item.meta}</p>
             <h3>{item.title}</h3>
@@ -104,21 +90,46 @@
       </div>
     </section>
 
-    <section id="contact" class="content-section contact-section">
-      <div class="section-heading">
-        <p class="eyebrow">{data.copy.nav.contact}</p>
-        <h2>{data.copy.contactTitle}</h2>
-        <p>{data.copy.contactBody}</p>
+    <section id="writing" class="content-section">
+      <div class="section-heading section-heading-wide">
+        <p class="eyebrow">{data.copy.writing.eyebrow}</p>
+        <h2>{data.copy.writing.title}</h2>
+        <p>{data.copy.writing.body}</p>
       </div>
 
-      <div class="contact-links">
-        {#each data.copy.links as link}
-          <a href={link.href} target={link.href.startsWith('http') ? '_blank' : undefined} rel={link.href.startsWith('http') ? 'noreferrer' : undefined}>
-            <span>{link.label}</span>
-            <span>{link.href.replace('mailto:', '')}</span>
-          </a>
+      <div class="post-grid">
+        {#each featuredPosts as post}
+          <article class="post-card">
+            <p class="post-meta">{post.date} · {post.readTime}</p>
+            <h3>{post.title}</h3>
+            <p>{post.excerpt}</p>
+            <div class="post-tags">
+              {#each post.tags as tag}
+                <span>{tag}</span>
+              {/each}
+            </div>
+            <a class="post-link" href={`/blog/${post.slug}`}>{data.copy.ui.readArticle}</a>
+          </article>
         {/each}
       </div>
+
+      <a class="archive-link" href="/blog">{data.copy.ui.viewFullArchive}</a>
+    </section>
+
+    <section id="contact" class="content-section">
+      <div class="section-heading section-heading-wide">
+        <p class="eyebrow">{data.copy.contact.eyebrow}</p>
+        <h2>{data.copy.contact.title}</h2>
+        <p>{data.copy.contact.body}</p>
+      </div>
+
+      <ContactForm
+        labels={data.copy.contact.form}
+        ui={data.copy.ui}
+        locale={data.copy.locale}
+        title={data.copy.contact.title}
+        note={data.copy.contact.note}
+      />
     </section>
   </main>
 

--- a/lda-front/src/routes/blog/+page.server.ts
+++ b/lda-front/src/routes/blog/+page.server.ts
@@ -4,14 +4,10 @@ import { getLocaleHref } from '$lib/locale';
 
 export const load: PageServerLoad = async ({ url }) => {
   const locale = resolveLocale(url.hostname);
-  const copy = getHomeCopy(locale);
-  const posts = getBlogPosts(locale);
-  const alternateHref = getLocaleHref(locale, `${url.pathname}${url.search}`);
-
   return {
     locale,
-    copy,
-    posts,
-    alternateHref,
+    copy: getHomeCopy(locale),
+    posts: getBlogPosts(locale),
+    alternateHref: getLocaleHref(locale, `${url.pathname}${url.search}`),
   };
 };

--- a/lda-front/src/routes/blog/+page.svelte
+++ b/lda-front/src/routes/blog/+page.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { PageData } from './$types';
+  import LocaleSwitch from '$lib/LocaleSwitch.svelte';
+
+  export let data: PageData;
+
+  onMount(() => {
+    document.documentElement.lang = data.copy.htmlLang;
+  });
+</script>
+
+<svelte:head>
+  <title>{data.copy.writing.title}</title>
+  <meta name="description" content={data.copy.writing.body} />
+</svelte:head>
+
+<div class="page-shell">
+  <header class="topbar topbar-tight" aria-label="Primary">
+    <div class="brand">
+      <span class="brand-mark">LD</span>
+      <div>
+        <p class="eyebrow">{data.copy.writing.eyebrow}</p>
+        <p class="brand-subline">{data.copy.ui.archive}</p>
+      </div>
+    </div>
+    <nav class="pill-nav">
+      <a href="/">{data.copy.ui.home}</a>
+      <a href="/#contact">{data.copy.nav.contact}</a>
+    </nav>
+    <LocaleSwitch locale={data.copy.locale} href={data.alternateHref} label={data.copy.ui.switchLocale} />
+  </header>
+
+  <main>
+    <section class="content-section">
+      <div class="section-heading section-heading-wide">
+        <p class="eyebrow">{data.copy.writing.eyebrow}</p>
+        <h1 class="archive-title">{data.copy.writing.title}</h1>
+        <p>{data.copy.writing.body}</p>
+      </div>
+
+      <div class="archive-list">
+        {#each data.posts as post}
+          <article class="archive-item">
+            <p class="post-meta">{post.date} · {post.readTime}</p>
+            <h2><a href={`/blog/${post.slug}`}>{post.title}</a></h2>
+            <p>{post.excerpt}</p>
+            <div class="post-tags">
+              {#each post.tags as tag}
+                <span>{tag}</span>
+              {/each}
+            </div>
+          </article>
+        {/each}
+      </div>
+    </section>
+  </main>
+</div>

--- a/lda-front/src/routes/blog/[slug]/+page.server.ts
+++ b/lda-front/src/routes/blog/[slug]/+page.server.ts
@@ -1,0 +1,20 @@
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+import { getBlogPost, getHomeCopy, resolveLocale } from '$lib/content';
+import { getLocaleHref } from '$lib/locale';
+
+export const load: PageServerLoad = async ({ params, url }) => {
+  const locale = resolveLocale(url.hostname);
+  const post = getBlogPost(locale, params.slug);
+
+  if (!post) {
+    throw error(404, 'Not found');
+  }
+
+  return {
+    locale,
+    copy: getHomeCopy(locale),
+    post,
+    alternateHref: getLocaleHref(locale, `${url.pathname}${url.search}`),
+  };
+};

--- a/lda-front/src/routes/blog/[slug]/+page.svelte
+++ b/lda-front/src/routes/blog/[slug]/+page.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import type { PageData } from './$types';
+  import LocaleSwitch from '$lib/LocaleSwitch.svelte';
+
+  export let data: PageData;
+
+  onMount(() => {
+    document.documentElement.lang = data.copy.htmlLang;
+  });
+</script>
+
+<svelte:head>
+  <title>{data.post.title}</title>
+  <meta name="description" content={data.post.excerpt} />
+</svelte:head>
+
+<div class="page-shell">
+  <header class="topbar topbar-tight" aria-label="Primary">
+    <div class="brand">
+      <span class="brand-mark">LD</span>
+      <div>
+        <p class="eyebrow">{data.copy.writing.eyebrow}</p>
+        <p class="brand-subline">{data.post.date}</p>
+      </div>
+    </div>
+    <nav class="pill-nav">
+      <a href="/blog">{data.copy.ui.archive}</a>
+      <a href="/">{data.copy.ui.home}</a>
+    </nav>
+    <LocaleSwitch locale={data.copy.locale} href={data.alternateHref} label={data.copy.ui.switchLocale} />
+  </header>
+
+  <main>
+    <article class="article-shell">
+      <p class="post-meta">{data.post.readTime}</p>
+      <h1 class="article-title">{data.post.title}</h1>
+      <p class="article-excerpt">{data.post.excerpt}</p>
+
+      <div class="post-tags">
+        {#each data.post.tags as tag}
+          <span>{tag}</span>
+        {/each}
+      </div>
+
+      {#if data.post.cover}
+        <img class="article-cover" src={data.post.cover} alt={data.post.title} />
+      {/if}
+
+      <div class="article-body">
+        {#each data.post.sections as section}
+          <section class="article-section">
+            <h2>{section.heading}</h2>
+            {#each section.paragraphs as paragraph}
+              <p>{paragraph}</p>
+            {/each}
+            {#if section.bullets}
+              <ul>
+                {#each section.bullets as bullet}
+                  <li>{bullet}</li>
+                {/each}
+              </ul>
+            {/if}
+          </section>
+        {/each}
+      </div>
+    </article>
+  </main>
+</div>


### PR DESCRIPTION
Add a visual locale switch, preserve the current route across domains, and keep the blog/contact/i18n updates in the SvelteKit migration.