### PR TITLE
[codex] thin header navbar further

### DIFF
--- a/lda-front/src/app.css
+++ b/lda-front/src/app.css
@@ -59,15 +59,15 @@ img {
 
 .topbar {
   position: sticky;
-  top: 1rem;
+  top: 0.75rem;
   z-index: 30;
   display: grid;
   grid-template-columns: 1fr auto auto;
-  gap: 0.85rem;
+  gap: 0.55rem;
   align-items: center;
   width: 100%;
-  margin-bottom: 2.25rem;
-  padding: 0.62rem 0.8rem;
+  margin-bottom: 1.5rem;
+  padding: 0.38rem 0.6rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 999px;
   background: rgba(10, 10, 11, 0.76);
@@ -78,20 +78,20 @@ img {
 .brand {
   display: flex;
   align-items: center;
-  gap: 0.9rem;
+  gap: 0.65rem;
   min-width: 0;
 }
 
 .brand-mark {
   display: inline-grid;
   place-items: center;
-  width: 2.35rem;
-  height: 2.35rem;
+  width: 1.95rem;
+  height: 1.95rem;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 0.65rem;
   color: var(--accent);
   font-family: 'Geist Mono', ui-monospace, monospace;
-  font-size: 0.72rem;
+  font-size: 0.66rem;
   letter-spacing: 0.08em;
 }
 
@@ -119,15 +119,15 @@ footer p {
 .eyebrow {
   margin: 0 0 0.45rem;
   color: var(--fg-3);
-  font-size: 0.68rem;
+  font-size: 0.64rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
 .pill-nav {
   display: inline-flex;
-  gap: 0.4rem;
-  padding: 0.2rem;
+  gap: 0.3rem;
+  padding: 0.12rem;
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.02);
@@ -139,10 +139,10 @@ footer p {
 }
 
 .pill-nav a {
-  padding: 0.48rem 0.78rem;
+  padding: 0.34rem 0.62rem;
   border-radius: 999px;
   color: var(--fg-2);
-  font-size: 0.8rem;
+  font-size: 0.74rem;
 }
 
 .pill-nav a:hover,
@@ -153,11 +153,11 @@ footer p {
 }
 
 .locale-badge {
-  padding: 0.48rem 0.75rem;
+  padding: 0.34rem 0.62rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 999px;
   color: var(--accent);
-  font-size: 0.68rem;
+  font-size: 0.64rem;
   letter-spacing: 0.08em;
 }
 
@@ -382,7 +382,7 @@ h3 {
 .work-meta {
   margin: 0 0 0.9rem;
   color: var(--accent-2);
-  font-size: 0.72rem;
+  font-size: 0.66rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -444,7 +444,7 @@ footer p {
 .post-meta {
   margin: 0 0 0.75rem;
   color: var(--accent-2);
-  font-size: 0.68rem;
+  font-size: 0.64rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -562,7 +562,7 @@ footer {
 @media (max-width: 980px) {
   .topbar {
     grid-template-columns: 1fr;
-    border-radius: 1rem;
+    border-radius: 0.85rem;
   }
 
   .pill-nav {

--- a/lda-front/src/app.css
+++ b/lda-front/src/app.css
@@ -59,15 +59,15 @@ img {
 
 .topbar {
   position: sticky;
-  top: 0.75rem;
+  top: 0.55rem;
   z-index: 30;
   display: grid;
   grid-template-columns: 1fr auto auto;
-  gap: 0.55rem;
+  gap: 0.4rem;
   align-items: center;
   width: 100%;
-  margin-bottom: 1.5rem;
-  padding: 0.38rem 0.6rem;
+  margin-bottom: 1.15rem;
+  padding: 0.26rem 0.48rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 999px;
   background: rgba(10, 10, 11, 0.76);
@@ -78,20 +78,20 @@ img {
 .brand {
   display: flex;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.5rem;
   min-width: 0;
 }
 
 .brand-mark {
   display: inline-grid;
   place-items: center;
-  width: 1.95rem;
-  height: 1.95rem;
+  width: 1.7rem;
+  height: 1.7rem;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 0.65rem;
   color: var(--accent);
   font-family: 'Geist Mono', ui-monospace, monospace;
-  font-size: 0.66rem;
+  font-size: 0.62rem;
   letter-spacing: 0.08em;
 }
 
@@ -119,15 +119,15 @@ footer p {
 .eyebrow {
   margin: 0 0 0.45rem;
   color: var(--fg-3);
-  font-size: 0.64rem;
+  font-size: 0.62rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
 .pill-nav {
   display: inline-flex;
-  gap: 0.3rem;
-  padding: 0.12rem;
+  gap: 0.22rem;
+  padding: 0.08rem;
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.02);
@@ -139,10 +139,10 @@ footer p {
 }
 
 .pill-nav a {
-  padding: 0.34rem 0.62rem;
+  padding: 0.26rem 0.52rem;
   border-radius: 999px;
   color: var(--fg-2);
-  font-size: 0.74rem;
+  font-size: 0.7rem;
 }
 
 .pill-nav a:hover,
@@ -153,11 +153,11 @@ footer p {
 }
 
 .locale-badge {
-  padding: 0.34rem 0.62rem;
+  padding: 0.26rem 0.52rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 999px;
   color: var(--accent);
-  font-size: 0.64rem;
+  font-size: 0.62rem;
   letter-spacing: 0.08em;
 }
 
@@ -320,7 +320,7 @@ h3 {
 .highlights {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65rem;
+  gap: 0.5rem;
   margin: 1.4rem 0 3.5rem;
 }
 
@@ -329,7 +329,7 @@ h3 {
   border: 1px solid var(--line);
   border-radius: 999px;
   color: var(--fg-2);
-  font-size: 0.74rem;
+  font-size: 0.7rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
@@ -382,7 +382,7 @@ h3 {
 .work-meta {
   margin: 0 0 0.9rem;
   color: var(--accent-2);
-  font-size: 0.66rem;
+  font-size: 0.62rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -444,7 +444,7 @@ footer p {
 .post-meta {
   margin: 0 0 0.75rem;
   color: var(--accent-2);
-  font-size: 0.64rem;
+  font-size: 0.62rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -462,7 +462,7 @@ footer p {
   border-radius: 999px;
   color: var(--fg-3);
   font-family: 'Geist Mono', ui-monospace, monospace;
-  font-size: 0.66rem;
+  font-size: 0.62rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
@@ -505,7 +505,7 @@ footer p {
 .article-cover {
   width: 100%;
   margin-top: 1.2rem;
-  border-radius: 0.85rem;
+  border-radius: 0.8rem;
   border: 1px solid var(--line);
 }
 
@@ -562,7 +562,7 @@ footer {
 @media (max-width: 980px) {
   .topbar {
     grid-template-columns: 1fr;
-    border-radius: 0.85rem;
+    border-radius: 0.8rem;
   }
 
   .pill-nav {


### PR DESCRIPTION
## What changed
- Tightened the sticky header/navbar again.
- Reduced topbar padding, gaps, brand mark size, pill spacing, and locale badge size.
- Kept the same structure and behavior.

## Validation
- `npm run check`
