### PR TITLE
[codex] publish i18n bundles

### DIFF
--- a/lda-front/package.json
+++ b/lda-front/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-    "start": "node build"
+    "start": "node build",
+    "publish:i18n": "node scripts/publish-i18n-bundles.mjs"
   },
   "devDependencies": {
     "@sveltejs/adapter-node": "^5.2.0",

--- a/lda-front/scripts/publish-i18n-bundles.mjs
+++ b/lda-front/scripts/publish-i18n-bundles.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const CMS_API_URL = (process.env.CMS_API_URL ?? 'https://cms.rbxsystems.ch').replace(/\/$/, '');
+const CMS_SERVICE_KEY = process.env.CMS_SERVICE_KEY;
+const LEGACY_SOURCE_COMMIT = process.env.LEGACY_SOURCE_COMMIT ?? '84fd945';
+const REPO_ROOT = process.cwd();
+
+if (!CMS_SERVICE_KEY) {
+  throw new Error('CMS_SERVICE_KEY is required');
+}
+
+function extractObjectLiteral(source, marker) {
+  const start = source.indexOf(marker);
+  if (start === -1) {
+    throw new Error(`marker not found: ${marker}`);
+  }
+
+  const braceStart = source.indexOf('{', start);
+  if (braceStart === -1) {
+    throw new Error(`opening brace not found for: ${marker}`);
+  }
+
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+
+  for (let i = braceStart; i < source.length; i += 1) {
+    const ch = source[i];
+
+    if (quote) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (ch === '\\') {
+        escaped = true;
+        continue;
+      }
+      if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+      continue;
+    }
+
+    if (ch === '{') {
+      depth += 1;
+      continue;
+    }
+
+    if (ch === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(braceStart, i + 1);
+      }
+    }
+  }
+
+  throw new Error(`unterminated object for: ${marker}`);
+}
+
+function parseJsObject(source, marker, context = {}) {
+  const literal = extractObjectLiteral(source, marker);
+  const keys = Object.keys(context);
+  const values = Object.values(context);
+  return Function(...keys, `return (${literal});`)(...values);
+}
+
+function getCurrentHomeBundles() {
+  const source = readFileSync(resolve(REPO_ROOT, 'src/lib/content.ts'), 'utf8');
+  const commonLinks = parseJsObject(source, "const COMMON_LINKS: LinkItem[] = " );
+  return {
+    en: parseJsObject(source, "const EN: HomeCopy = ", { COMMON_LINKS: commonLinks }),
+    ptBR: parseJsObject(source, "const PT: HomeCopy = ", { COMMON_LINKS: commonLinks }),
+  };
+}
+
+function getLegacyArchive() {
+  const locales = ['de', 'en', 'es', 'fr', 'it', 'pt', 'zh'];
+  const archive = {};
+
+  for (const locale of locales) {
+    const treeLine = execFileSync('git', ['ls-tree', LEGACY_SOURCE_COMMIT, `app/[lang]/dictionaries/${locale}.json`], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    }).trim();
+    if (!treeLine) {
+      throw new Error(`legacy bundle missing: ${locale}`);
+    }
+
+    const parts = treeLine.split(/\s+/);
+    const blob = parts[2];
+    const raw = execFileSync('git', ['cat-file', '-p', blob], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+    });
+    archive[locale] = JSON.parse(raw);
+  }
+
+  return {
+    sourceCommit: LEGACY_SOURCE_COMMIT,
+    locales: archive,
+  };
+}
+
+async function cmsFetch(path, { method = 'GET', body } = {}) {
+  const response = await fetch(`${CMS_API_URL}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${CMS_SERVICE_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`${method} ${path} failed: ${response.status} ${await response.text()}`);
+  }
+
+  return response;
+}
+
+async function saveAndPublishPage(key, locale, frontmatter, bundle) {
+  const body = {
+    frontmatter,
+    body: JSON.stringify(bundle, null, 2) + '\n',
+  };
+
+  await cmsFetch(`/api/v1/pages/${encodeURIComponent(key)}/${locale}`, { method: 'PUT', body });
+  const publish = await cmsFetch(`/api/v1/pages/${encodeURIComponent(key)}/${locale}/publish`, { method: 'POST' });
+  return publish.json();
+}
+
+async function main() {
+  const { en, ptBR } = getCurrentHomeBundles();
+  const legacyArchive = getLegacyArchive();
+
+  const results = [];
+  results.push(await saveAndPublishPage('translations-home', 'pt-BR', {
+    title: 'Home translation bundle',
+    description: 'Portuguese home content bundle stored as JSON in S3.',
+  }, ptBR));
+  results.push(await saveAndPublishPage('translations-home', 'en', {
+    title: 'Home translation bundle',
+    description: 'English home content bundle stored as JSON in S3.',
+  }, en));
+  results.push(await saveAndPublishPage('translations-legacy', 'pt-BR', {
+    title: 'Legacy translation archive',
+    description: `Archive of legacy Next translation bundles from ${LEGACY_SOURCE_COMMIT}.`,
+  }, legacyArchive));
+  results.push(await saveAndPublishPage('translations-legacy', 'en', {
+    title: 'Legacy translation archive',
+    description: `Archive of legacy Next translation bundles from ${LEGACY_SOURCE_COMMIT}.`,
+  }, legacyArchive));
+
+  console.log(JSON.stringify(results, null, 2));
+}
+
+await main();

--- a/lda-front/src/app.css
+++ b/lda-front/src/app.css
@@ -59,15 +59,15 @@ img {
 
 .topbar {
   position: sticky;
-  top: 1rem;
+  top: 0.75rem;
   z-index: 30;
   display: grid;
   grid-template-columns: 1fr auto auto;
-  gap: 0.85rem;
+  gap: 0.55rem;
   align-items: center;
   width: 100%;
-  margin-bottom: 2.25rem;
-  padding: 0.62rem 0.8rem;
+  margin-bottom: 1.5rem;
+  padding: 0.38rem 0.6rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 999px;
   background: rgba(10, 10, 11, 0.76);
@@ -78,20 +78,20 @@ img {
 .brand {
   display: flex;
   align-items: center;
-  gap: 0.9rem;
+  gap: 0.65rem;
   min-width: 0;
 }
 
 .brand-mark {
   display: inline-grid;
   place-items: center;
-  width: 2.35rem;
-  height: 2.35rem;
+  width: 1.95rem;
+  height: 1.95rem;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 0.65rem;
   color: var(--accent);
   font-family: 'Geist Mono', ui-monospace, monospace;
-  font-size: 0.72rem;
+  font-size: 0.66rem;
   letter-spacing: 0.08em;
 }
 
@@ -119,15 +119,15 @@ footer p {
 .eyebrow {
   margin: 0 0 0.45rem;
   color: var(--fg-3);
-  font-size: 0.68rem;
+  font-size: 0.64rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
 .pill-nav {
   display: inline-flex;
-  gap: 0.4rem;
-  padding: 0.2rem;
+  gap: 0.3rem;
+  padding: 0.12rem;
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.02);
@@ -139,10 +139,10 @@ footer p {
 }
 
 .pill-nav a {
-  padding: 0.48rem 0.78rem;
+  padding: 0.34rem 0.62rem;
   border-radius: 999px;
   color: var(--fg-2);
-  font-size: 0.8rem;
+  font-size: 0.74rem;
 }
 
 .pill-nav a:hover,
@@ -153,11 +153,11 @@ footer p {
 }
 
 .locale-badge {
-  padding: 0.48rem 0.75rem;
+  padding: 0.34rem 0.62rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 999px;
   color: var(--accent);
-  font-size: 0.68rem;
+  font-size: 0.64rem;
   letter-spacing: 0.08em;
 }
 
@@ -382,7 +382,7 @@ h3 {
 .work-meta {
   margin: 0 0 0.9rem;
   color: var(--accent-2);
-  font-size: 0.72rem;
+  font-size: 0.66rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -444,7 +444,7 @@ footer p {
 .post-meta {
   margin: 0 0 0.75rem;
   color: var(--accent-2);
-  font-size: 0.68rem;
+  font-size: 0.64rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -562,7 +562,7 @@ footer {
 @media (max-width: 980px) {
   .topbar {
     grid-template-columns: 1fr;
-    border-radius: 1rem;
+    border-radius: 0.85rem;
   }
 
   .pill-nav {

--- a/lda-front/src/app.css
+++ b/lda-front/src/app.css
@@ -59,15 +59,15 @@ img {
 
 .topbar {
   position: sticky;
-  top: 0.75rem;
+  top: 0.55rem;
   z-index: 30;
   display: grid;
   grid-template-columns: 1fr auto auto;
-  gap: 0.55rem;
+  gap: 0.4rem;
   align-items: center;
   width: 100%;
-  margin-bottom: 1.5rem;
-  padding: 0.38rem 0.6rem;
+  margin-bottom: 1.15rem;
+  padding: 0.26rem 0.48rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 999px;
   background: rgba(10, 10, 11, 0.76);
@@ -78,20 +78,20 @@ img {
 .brand {
   display: flex;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.5rem;
   min-width: 0;
 }
 
 .brand-mark {
   display: inline-grid;
   place-items: center;
-  width: 1.95rem;
-  height: 1.95rem;
+  width: 1.7rem;
+  height: 1.7rem;
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 0.65rem;
   color: var(--accent);
   font-family: 'Geist Mono', ui-monospace, monospace;
-  font-size: 0.66rem;
+  font-size: 0.62rem;
   letter-spacing: 0.08em;
 }
 
@@ -119,15 +119,15 @@ footer p {
 .eyebrow {
   margin: 0 0 0.45rem;
   color: var(--fg-3);
-  font-size: 0.64rem;
+  font-size: 0.62rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
 .pill-nav {
   display: inline-flex;
-  gap: 0.3rem;
-  padding: 0.12rem;
+  gap: 0.22rem;
+  padding: 0.08rem;
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.02);
@@ -139,10 +139,10 @@ footer p {
 }
 
 .pill-nav a {
-  padding: 0.34rem 0.62rem;
+  padding: 0.26rem 0.52rem;
   border-radius: 999px;
   color: var(--fg-2);
-  font-size: 0.74rem;
+  font-size: 0.7rem;
 }
 
 .pill-nav a:hover,
@@ -153,11 +153,11 @@ footer p {
 }
 
 .locale-badge {
-  padding: 0.34rem 0.62rem;
+  padding: 0.26rem 0.52rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 999px;
   color: var(--accent);
-  font-size: 0.64rem;
+  font-size: 0.62rem;
   letter-spacing: 0.08em;
 }
 
@@ -320,7 +320,7 @@ h3 {
 .highlights {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.65rem;
+  gap: 0.5rem;
   margin: 1.4rem 0 3.5rem;
 }
 
@@ -329,7 +329,7 @@ h3 {
   border: 1px solid var(--line);
   border-radius: 999px;
   color: var(--fg-2);
-  font-size: 0.74rem;
+  font-size: 0.7rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
@@ -382,7 +382,7 @@ h3 {
 .work-meta {
   margin: 0 0 0.9rem;
   color: var(--accent-2);
-  font-size: 0.66rem;
+  font-size: 0.62rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -444,7 +444,7 @@ footer p {
 .post-meta {
   margin: 0 0 0.75rem;
   color: var(--accent-2);
-  font-size: 0.64rem;
+  font-size: 0.62rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -462,7 +462,7 @@ footer p {
   border-radius: 999px;
   color: var(--fg-3);
   font-family: 'Geist Mono', ui-monospace, monospace;
-  font-size: 0.66rem;
+  font-size: 0.62rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
@@ -505,7 +505,7 @@ footer p {
 .article-cover {
   width: 100%;
   margin-top: 1.2rem;
-  border-radius: 0.85rem;
+  border-radius: 0.8rem;
   border: 1px solid var(--line);
 }
 
@@ -562,7 +562,7 @@ footer {
 @media (max-width: 980px) {
   .topbar {
     grid-template-columns: 1fr;
-    border-radius: 0.85rem;
+    border-radius: 0.8rem;
   }
 
   .pill-nav {

--- a/lda-front/src/lib/ContactForm.svelte
+++ b/lda-front/src/lib/ContactForm.svelte
@@ -79,7 +79,16 @@
   }
 </script>
 
-<section class="contact-shell">
+<section class="contact-shell" aria-busy={status === "submitting"}>
+  {#if status === "submitting"}
+    <div class="freeze-overlay" role="status" aria-live="polite" aria-label={ui.altchaLoading}>
+      <div class="freeze-panel">
+        <p class="eyebrow">{title}</p>
+        <h3>{ui.altchaLoading}</h3>
+        <p>{labels.submitting}</p>
+      </div>
+    </div>
+  {/if}
   <div class="contact-copy">
     <p class="eyebrow">{title}</p>
     <h3>{note}</h3>
@@ -94,46 +103,48 @@
     </div>
   {:else}
     <form class="form-card" on:submit|preventDefault={handleSubmit}>
-      <input class="honeypot" aria-hidden="true" tabindex="-1" autocomplete="off" bind:value={website} />
+      <fieldset class="form-fieldset" disabled={status === 'submitting'}>
+        <input class="honeypot" aria-hidden="true" tabindex="-1" autocomplete="off" bind:value={website} />
 
-      <div class="row">
+        <div class="row">
+          <label>
+            <span>{labels.name}</span>
+            <input bind:value={name} placeholder={labels.namePlaceholder} required />
+          </label>
+          <label>
+            <span>{labels.email}</span>
+            <input bind:value={email} placeholder={labels.emailPlaceholder} />
+          </label>
+        </div>
+
         <label>
-          <span>{labels.name}</span>
-          <input bind:value={name} placeholder={labels.namePlaceholder} required />
+          <span>{labels.phone}</span>
+          <input bind:value={phone} placeholder={labels.phonePlaceholder} />
         </label>
+
         <label>
-          <span>{labels.email}</span>
-          <input bind:value={email} placeholder={labels.emailPlaceholder} />
+          <span>{labels.message}</span>
+          <textarea bind:value={message} placeholder={labels.messagePlaceholder} rows="5" required></textarea>
         </label>
-      </div>
 
-      <label>
-        <span>{labels.phone}</span>
-        <input bind:value={phone} placeholder={labels.phonePlaceholder} />
-      </label>
+        <label class="checkbox-row">
+          <input type="checkbox" bind:checked={whatsappOptIn} />
+          <span>{labels.whatsappOptIn}</span>
+        </label>
 
-      <label>
-        <span>{labels.message}</span>
-        <textarea bind:value={message} placeholder={labels.messagePlaceholder} rows="5" required></textarea>
-      </label>
+        <div class="challenge-row">
+          <AltchaWidget challengeurl={challengeUrl} ui={ui} onstatechange={(payload) => (altchaPayload = payload)} />
+          <p>{labels.submit}</p>
+        </div>
 
-      <label class="checkbox-row">
-        <input type="checkbox" bind:checked={whatsappOptIn} />
-        <span>{labels.whatsappOptIn}</span>
-      </label>
+        {#if status === 'error'}
+          <p class="error" role="alert">{errorText}</p>
+        {/if}
 
-      <div class="challenge-row">
-        <AltchaWidget challengeurl={challengeUrl} ui={ui} onstatechange={(payload) => (altchaPayload = payload)} />
-        <p>{labels.submit}</p>
-      </div>
-
-      {#if status === 'error'}
-        <p class="error" role="alert">{errorText}</p>
-      {/if}
-
-      <button class="submit" type="submit" disabled={status === 'submitting'}>
-        {status === 'submitting' ? labels.submitting : labels.submit}
-      </button>
+        <button class="submit" type="submit" disabled={status === 'submitting'}>
+          {status === 'submitting' ? labels.submitting : labels.submit}
+        </button>
+      </fieldset>
     </form>
   {/if}
 </section>
@@ -175,6 +186,52 @@
     border: 1px solid var(--line);
     border-radius: 0.95rem;
     background: rgba(255, 255, 255, 0.02);
+  }
+
+  .form-fieldset {
+    display: grid;
+    gap: 0.9rem;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    min-width: 0;
+  }
+
+  .form-fieldset:disabled {
+    opacity: 0.72;
+  }
+
+  .freeze-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: grid;
+    place-items: center;
+    padding: 1rem;
+    background: rgba(5, 5, 7, 0.68);
+    backdrop-filter: blur(10px);
+  }
+
+  .freeze-panel {
+    width: min(32rem, 100%);
+    padding: 1.1rem 1.2rem;
+    border: 1px solid var(--line-strong);
+    border-radius: 1rem;
+    background: rgba(10, 10, 11, 0.96);
+    box-shadow: var(--shadow);
+  }
+
+  .freeze-panel h3 {
+    margin: 0.25rem 0 0.35rem;
+    font-size: 1.05rem;
+    font-weight: 400;
+    color: var(--fg);
+  }
+
+  .freeze-panel p {
+    margin: 0;
+    color: var(--fg-2);
+    font-size: 0.9rem;
   }
 
   .form-success {

--- a/lda-front/src/lib/content.ts
+++ b/lda-front/src/lib/content.ts
@@ -1,3 +1,5 @@
+import { readContaboObject } from '$lib/s3';
+
 export type Locale = 'pt-BR' | 'en';
 
 export type WorkStatus = 'active' | 'shipped' | 'production' | 'in-progress';
@@ -116,6 +118,142 @@ const COMMON_LINKS: LinkItem[] = [
   { label: 'linkedin.com/in/ldamasio', href: 'https://www.linkedin.com/in/ldamasio/' },
 ];
 
+const HOME_BUNDLE_KEY = 'translations-home';
+const LEGACY_TRANSLATION_BUNDLE_KEY = 'translations-legacy';
+const HOME_BUNDLE_TTL_MS = 5 * 60 * 1000;
+const LEGACY_BUNDLE_TTL_MS = 15 * 60 * 1000;
+
+type CachedCopy = {
+  loadedAt: number;
+  copy: HomeCopy;
+};
+
+type LegacyTranslationArchive = {
+  sourceCommit: string;
+  locales: Record<string, unknown>;
+};
+
+type CachedLegacyCopy = {
+  loadedAt: number;
+  archive: LegacyTranslationArchive;
+};
+
+const HOME_COPY_CACHE = new Map<Locale, CachedCopy>();
+const LEGACY_COPY_CACHE = new Map<Locale, CachedLegacyCopy>();
+
+function homeBundleKey(locale: Locale): string {
+  return `site/${locale}/${HOME_BUNDLE_KEY}/index.md`;
+}
+
+function legacyBundleKey(locale: Locale): string {
+  return `site/${locale}/${LEGACY_TRANSLATION_BUNDLE_KEY}/index.md`;
+}
+
+function stripFrontmatter(raw: string): string {
+  const normalized = raw.replace(/\r?\n/g, '\n');
+  if (!normalized.startsWith('---\n')) {
+    return normalized;
+  }
+
+  const end = normalized.indexOf('\n---\n', 4);
+  if (end === -1) {
+    return normalized;
+  }
+
+  return normalized.slice(end + 5);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function mergeDeep<T>(base: T, override: unknown): T {
+  if (!isPlainObject(base) || !isPlainObject(override)) {
+    return (override as T) ?? base;
+  }
+
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    const current = (base as Record<string, unknown>)[key];
+    if (Array.isArray(value)) {
+      result[key] = value;
+      continue;
+    }
+
+    if (isPlainObject(current) && isPlainObject(value)) {
+      result[key] = mergeDeep(current, value);
+      continue;
+    }
+
+    result[key] = value;
+  }
+
+  return result as T;
+}
+
+async function readRemoteHomeCopy(locale: Locale): Promise<Partial<HomeCopy> | null> {
+  try {
+    const bodyText = await readContaboObject(homeBundleKey(locale));
+    if (!bodyText) {
+      return null;
+    }
+
+    const body = stripFrontmatter(bodyText).trim();
+    if (!body) {
+      return null;
+    }
+
+    return JSON.parse(body) as Partial<HomeCopy>;
+  } catch {
+    return null;
+  }
+}
+
+async function loadHomeCopy(locale: Locale): Promise<HomeCopy> {
+  const cached = HOME_COPY_CACHE.get(locale);
+  if (cached && Date.now() - cached.loadedAt < HOME_BUNDLE_TTL_MS) {
+    return cached.copy;
+  }
+
+  const remote = await readRemoteHomeCopy(locale);
+  const copy = remote ? mergeDeep(COPY[locale], remote) : COPY[locale];
+  HOME_COPY_CACHE.set(locale, { loadedAt: Date.now(), copy });
+  return copy;
+}
+
+async function readRemoteLegacyArchive(locale: Locale): Promise<LegacyTranslationArchive | null> {
+  try {
+    const bodyText = await readContaboObject(legacyBundleKey(locale));
+    if (!bodyText) {
+      return null;
+    }
+
+    const body = stripFrontmatter(bodyText).trim();
+    if (!body) {
+      return null;
+    }
+
+    return JSON.parse(body) as LegacyTranslationArchive;
+  } catch {
+    return null;
+  }
+}
+
+async function loadLegacyArchive(locale: Locale): Promise<LegacyTranslationArchive | null> {
+  const cached = LEGACY_COPY_CACHE.get(locale);
+  if (cached && Date.now() - cached.loadedAt < LEGACY_BUNDLE_TTL_MS) {
+    return cached.archive;
+  }
+
+  const archive = await readRemoteLegacyArchive(locale);
+  if (!archive) {
+    return null;
+  }
+
+  LEGACY_COPY_CACHE.set(locale, { loadedAt: Date.now(), archive });
+  return archive;
+}
+
 const EN: HomeCopy = {
   locale: 'en',
   htmlLang: 'en',
@@ -129,11 +267,11 @@ const EN: HomeCopy = {
     title: 'Leandro Damasio',
     lead: 'Computer Engineer. AI systems for finance and high-reliability environments.',
     body: [
-      'AI Engineer at Enforce (BTG Pactual Group), based in São Paulo, Brazil. Builds production-grade AI systems for financial and legal domains where reliability, observability, and governance are not optional.',
+      'AI Engineer at Enforce (BTG Pactual Group), based in São Paulo. Builds production-grade AI systems for financial and legal domains where reliability, observability, and governance are not optional.',
       'Work spans AI, software architecture, and infrastructure: agentic architectures, runtime control loops, evaluation and monitoring pipelines for LLM-based systems. Hands-on with vector search using pgvector and ParadeDB, prompt governance, and secure integration with internal and external data sources.',
       'Founder and maintainer of RBX Systems, an open-source monorepo of AI agents, code agents, and system-level tooling focused on architecture and long-term maintainability.',
     ],
-    location: 'Brazil · Zürich / São Paulo',
+    location: 'São Paulo',
     status: 'Available for selected engagements.',
   },
   team: {
@@ -331,11 +469,11 @@ const PT: HomeCopy = {
     title: 'Leandro Damasio',
     lead: 'Engenheiro de Computação. Sistemas de IA para finanças e ambientes de alta confiabilidade.',
     body: [
-      'Engenheiro de IA na Enforce (Grupo BTG Pactual), baseado em São Paulo, Brasil. Constrói sistemas de IA prontos para produção para os domínios financeiro e jurídico onde confiabilidade, observabilidade e governança são requisitos de base.',
+      'Engenheiro de IA na Enforce (Grupo BTG Pactual), baseado em São Paulo. Constrói sistemas de IA prontos para produção para os domínios financeiro e jurídico onde confiabilidade, observabilidade e governança são requisitos de base.',
       'Trabalho abrange IA, arquitetura de software e infraestrutura: arquiteturas de agentes, loops de controle de runtime, pipelines de avaliação e monitoramento para sistemas baseados em LLM. Experiência prática com busca vetorial usando pgvector e ParadeDB, governança de prompts e integração segura com fontes de dados internas e externas.',
       'Fundador e mantenedor da RBX Systems, monorepo open-source de agentes de IA, agentes de código e ferramentas de nível de sistema com foco em arquitetura e manutenibilidade de longo prazo.',
     ],
-    location: 'Brasil · Zürich / São Paulo',
+    location: 'São Paulo',
     status: 'Disponível para projetos selecionados.',
   },
   team: {
@@ -529,6 +667,10 @@ export function resolveLocale(hostname: string): Locale {
   return hostname.endsWith('.ch') ? 'en' : 'pt-BR';
 }
 
-export function getHomeCopy(locale: Locale): HomeCopy {
-  return COPY[locale];
+export async function getHomeCopy(locale: Locale): Promise<HomeCopy> {
+  return await loadHomeCopy(locale);
+}
+
+export async function getLegacyTranslationArchive(locale: Locale): Promise<LegacyTranslationArchive | null> {
+  return await loadLegacyArchive(locale);
 }

--- a/lda-front/src/lib/content.ts
+++ b/lda-front/src/lib/content.ts
@@ -120,14 +120,14 @@ const EN: HomeCopy = {
     contact: 'Contact',
   },
   hero: {
-    eyebrow: 'Authorial engineering',
+    eyebrow: '',
     title: 'Leandro Damasio',
     lead: 'Computer Engineer. AI systems for finance and high-reliability environments.',
     body: [
       'AI Engineer at Enforce (BTG Pactual Group), based in São Paulo, Brazil. Builds production-grade AI systems for financial and legal domains where reliability, observability, and governance are not optional.',
       'Work spans AI, software architecture, and infrastructure: agentic architectures, runtime control loops, evaluation and monitoring pipelines for LLM-based systems. Hands-on with vector search using pgvector and ParadeDB, prompt governance, and secure integration with internal and external data sources.',
       'Founder and maintainer of RBX Systems, an open-source monorepo of AI agents, code agents, and system-level tooling focused on architecture and long-term maintainability.',
-      'Based in Brazil, working across Zürich and São Paulo. Available for selected engagements.',
+      'On a personal level, I am a strong problem solver with a passion for innovation. I thrive in collaborative environments and enjoy working with multidisciplinary teams. I am highly organized and able to prioritize tasks to deliver high-quality results on time.',
     ],
     location: 'Brazil · Zürich / São Paulo',
     status: 'Available for selected engagements.',
@@ -318,14 +318,14 @@ const PT: HomeCopy = {
     contact: 'Contato',
   },
   hero: {
-    eyebrow: 'Engenharia autoral',
+    eyebrow: '',
     title: 'Leandro Damasio',
     lead: 'Engenheiro de Computação. Sistemas de IA para finanças e ambientes de alta confiabilidade.',
     body: [
       'Engenheiro de IA na Enforce (Grupo BTG Pactual), baseado em São Paulo, Brasil. Constrói sistemas de IA prontos para produção para os domínios financeiro e jurídico onde confiabilidade, observabilidade e governança são requisitos de base.',
       'Trabalho abrange IA, arquitetura de software e infraestrutura: arquiteturas de agentes, loops de controle de runtime, pipelines de avaliação e monitoramento para sistemas baseados em LLM. Experiência prática com busca vetorial usando pgvector e ParadeDB, governança de prompts e integração segura com fontes de dados internas e externas.',
       'Fundador e mantenedor da RBX Systems, monorepo open-source de agentes de IA, agentes de código e ferramentas de nível de sistema com foco em arquitetura e manutenibilidade de longo prazo.',
-      'Baseado no Brasil, atuando entre Zürich e São Paulo. Disponível para projetos selecionados.',
+      'Em um nível pessoal, sou um forte solucionador de problemas com paixão por inovação. Eu prospero em ambientes colaborativos e gosto de trabalhar com equipes multidisciplinares. Sou altamente organizado e capaz de priorizar tarefas para entregar resultados de alta qualidade a tempo.',
     ],
     location: 'Brasil · Zürich / São Paulo',
     status: 'Disponível para projetos selecionados.',

--- a/lda-front/src/lib/content.ts
+++ b/lda-front/src/lib/content.ts
@@ -41,6 +41,11 @@ export type HomeCopy = {
     location: string;
     status: string;
   };
+  team: {
+    eyebrow: string;
+    title: string;
+    body: string;
+  };
   work: {
     eyebrow: string;
     title: string;
@@ -127,10 +132,14 @@ const EN: HomeCopy = {
       'AI Engineer at Enforce (BTG Pactual Group), based in São Paulo, Brazil. Builds production-grade AI systems for financial and legal domains where reliability, observability, and governance are not optional.',
       'Work spans AI, software architecture, and infrastructure: agentic architectures, runtime control loops, evaluation and monitoring pipelines for LLM-based systems. Hands-on with vector search using pgvector and ParadeDB, prompt governance, and secure integration with internal and external data sources.',
       'Founder and maintainer of RBX Systems, an open-source monorepo of AI agents, code agents, and system-level tooling focused on architecture and long-term maintainability.',
-      'On a personal level, I am a strong problem solver with a passion for innovation. I thrive in collaborative environments and enjoy working with multidisciplinary teams. I am highly organized and able to prioritize tasks to deliver high-quality results on time.',
     ],
     location: 'Brazil · Zürich / São Paulo',
     status: 'Available for selected engagements.',
+  },
+  team: {
+    eyebrow: 'Team',
+    title: 'Collaboration and multidisciplinary work',
+    body: 'On a personal level, I am a strong problem solver with a passion for innovation. I thrive in collaborative environments and enjoy working with multidisciplinary teams. I am highly organized and able to prioritize tasks to deliver high-quality results on time.',
   },
   work: {
     eyebrow: 'Selected Projects',
@@ -325,10 +334,14 @@ const PT: HomeCopy = {
       'Engenheiro de IA na Enforce (Grupo BTG Pactual), baseado em São Paulo, Brasil. Constrói sistemas de IA prontos para produção para os domínios financeiro e jurídico onde confiabilidade, observabilidade e governança são requisitos de base.',
       'Trabalho abrange IA, arquitetura de software e infraestrutura: arquiteturas de agentes, loops de controle de runtime, pipelines de avaliação e monitoramento para sistemas baseados em LLM. Experiência prática com busca vetorial usando pgvector e ParadeDB, governança de prompts e integração segura com fontes de dados internas e externas.',
       'Fundador e mantenedor da RBX Systems, monorepo open-source de agentes de IA, agentes de código e ferramentas de nível de sistema com foco em arquitetura e manutenibilidade de longo prazo.',
-      'Em um nível pessoal, sou um forte solucionador de problemas com paixão por inovação. Eu prospero em ambientes colaborativos e gosto de trabalhar com equipes multidisciplinares. Sou altamente organizado e capaz de priorizar tarefas para entregar resultados de alta qualidade a tempo.',
     ],
     location: 'Brasil · Zürich / São Paulo',
     status: 'Disponível para projetos selecionados.',
+  },
+  team: {
+    eyebrow: 'Equipe',
+    title: 'Colaboração e trabalho multidisciplinar',
+    body: 'Em um nível pessoal, sou um forte solucionador de problemas com paixão por inovação. Eu prospero em ambientes colaborativos e gosto de trabalhar com equipes multidisciplinares. Sou altamente organizado e capaz de priorizar tarefas para entregar resultados de alta qualidade a tempo.',
   },
   work: {
     eyebrow: 'Projetos selecionados',

--- a/lda-front/src/lib/notes.ts
+++ b/lda-front/src/lib/notes.ts
@@ -1,6 +1,8 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import { readContaboObject } from '$lib/s3';
+
 export type Locale = 'pt-BR' | 'en';
 export type NoteLocale = 'pt' | 'en';
 
@@ -27,8 +29,6 @@ export type Note = NoteMeta & {
 
 const NOTE_DIR = path.join(process.cwd(), 'notes');
 const NOTES_PREFIX = 'lda/notes/';
-const CONTABO_ENDPOINT = process.env.CONTABO_S3_ENDPOINT ?? 'https://eu2.contabostorage.com';
-const CONTABO_BUCKET = process.env.CONTABO_S3_CONTENT_BUCKET ?? 'rbx-content';
 
 export const NOTE_SLUGS = [
   'prompt-governance-regulated-environments',
@@ -179,14 +179,7 @@ async function readLocalNote(fileName: string): Promise<string | null> {
 }
 
 async function readRemoteNote(fileName: string): Promise<string | null> {
-  const url = `${CONTABO_ENDPOINT.replace(/\/$/, '')}/${CONTABO_BUCKET}/${NOTES_PREFIX}${fileName}`;
-  try {
-    const response = await fetch(url);
-    if (!response.ok) return null;
-    return await response.text();
-  } catch {
-    return null;
-  }
+  return await readContaboObject(`${NOTES_PREFIX}${fileName}`);
 }
 
 async function readNoteSource(slug: string, locale: Locale): Promise<string | null> {

--- a/lda-front/src/lib/s3.ts
+++ b/lda-front/src/lib/s3.ts
@@ -1,0 +1,85 @@
+import { createHash, createHmac } from 'node:crypto';
+
+const CONTABO_ENDPOINT = process.env.CONTABO_S3_ENDPOINT ?? 'https://eu2.contabostorage.com';
+const CONTABO_BUCKET = process.env.CONTABO_S3_CONTENT_BUCKET ?? 'rbx-content';
+const CONTABO_ACCESS_KEY = process.env.CONTABO_S3_ACCESS_KEY ?? process.env.AWS_ACCESS_KEY_ID;
+const CONTABO_SECRET_KEY = process.env.CONTABO_S3_SECRET_KEY ?? process.env.AWS_SECRET_ACCESS_KEY;
+const CONTABO_REGION = 'default';
+
+function hashHex(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function hmac(key: string | Buffer, value: string): Buffer {
+  return createHmac('sha256', key).update(value, 'utf8').digest();
+}
+
+function amzDate(now = new Date()): string {
+  return now.toISOString().replace(/[:-]|\.\d{3}/g, '');
+}
+
+function credentialScope(dateStamp: string): string {
+  return `${dateStamp}/${CONTABO_REGION}/s3/aws4_request`;
+}
+
+function encodeObjectKey(key: string): string {
+  return key.split('/').map((part) => encodeURIComponent(part)).join('/');
+}
+
+function signingKey(secretKey: string, dateStamp: string): Buffer {
+  const kDate = hmac(`AWS4${secretKey}`, dateStamp);
+  const kRegion = hmac(kDate, CONTABO_REGION);
+  const kService = hmac(kRegion, 's3');
+  return hmac(kService, 'aws4_request');
+}
+
+export function contaboObjectUrl(key: string): string {
+  return `${CONTABO_ENDPOINT.replace(/\/$/, '')}/${CONTABO_BUCKET}/${encodeObjectKey(key)}`;
+}
+
+export async function readContaboObject(key: string): Promise<string | null> {
+  if (!CONTABO_ACCESS_KEY || !CONTABO_SECRET_KEY) {
+    return null;
+  }
+
+  const url = contaboObjectUrl(key);
+  const now = new Date();
+  const amz = amzDate(now);
+  const dateStamp = amz.slice(0, 8);
+  const host = new URL(CONTABO_ENDPOINT).host;
+  const payloadHash = hashHex('');
+  const canonicalUri = `/${CONTABO_BUCKET}/${encodeObjectKey(key)}`;
+  const canonicalHeaders = `host:${host}\nx-amz-content-sha256:${payloadHash}\nx-amz-date:${amz}\n`;
+  const signedHeaders = 'host;x-amz-content-sha256;x-amz-date';
+  const canonicalRequest = [
+    'GET',
+    canonicalUri,
+    '',
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join('\n');
+  const stringToSign = [
+    'AWS4-HMAC-SHA256',
+    amz,
+    credentialScope(dateStamp),
+    hashHex(canonicalRequest),
+  ].join('\n');
+  const signature = createHmac('sha256', signingKey(CONTABO_SECRET_KEY, dateStamp))
+    .update(stringToSign, 'utf8')
+    .digest('hex');
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `AWS4-HMAC-SHA256 Credential=${CONTABO_ACCESS_KEY}/${credentialScope(dateStamp)}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+      'x-amz-content-sha256': payloadHash,
+      'x-amz-date': amz,
+    },
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  return await response.text();
+}

--- a/lda-front/src/lib/site.ts
+++ b/lda-front/src/lib/site.ts
@@ -64,7 +64,7 @@ const COPY: Record<Locale, SiteCopy> = {
       lead: 'Engenheiro de Computação. Sistemas de IA e interfaces para ambientes de alta confiabilidade.',
       body: 'Constrói produtos digitais, plataformas de automação e sistemas operacionais com rigor institucional. O foco é confiabilidade, observabilidade e clareza operacional.',
       status: 'Disponível para projetos selecionados',
-      location: 'Brasil · São Paulo / Zürich',
+      location: 'São Paulo',
       availability: 'PT-BR primeiro no domínio .rbx.ia.br. EN primeiro no .rbxsystems.ch.',
     },
     highlights: [
@@ -126,7 +126,7 @@ const COPY: Record<Locale, SiteCopy> = {
       lead: 'Computer Engineer. AI systems and interfaces for high-reliability environments.',
       body: 'Builds digital products, automation platforms and operational systems with institutional rigor. The emphasis is reliability, observability and operational clarity.',
       status: 'Available for selected engagements',
-      location: 'Brazil · São Paulo / Zürich',
+      location: 'São Paulo',
       availability: 'PT-BR leads on .rbx.ia.br. EN leads on .rbxsystems.ch.',
     },
     highlights: [

--- a/lda-front/src/lib/site.ts
+++ b/lda-front/src/lib/site.ts
@@ -59,7 +59,7 @@ const COPY: Record<Locale, SiteCopy> = {
       contact: 'Contato',
     },
     hero: {
-      eyebrow: 'Engenharia autoral',
+      eyebrow: '',
       title: 'Leandro Damasio',
       lead: 'Engenheiro de Computação. Sistemas de IA e interfaces para ambientes de alta confiabilidade.',
       body: 'Constrói produtos digitais, plataformas de automação e sistemas operacionais com rigor institucional. O foco é confiabilidade, observabilidade e clareza operacional.',
@@ -121,7 +121,7 @@ const COPY: Record<Locale, SiteCopy> = {
       contact: 'Contact',
     },
     hero: {
-      eyebrow: 'Authorial engineering',
+      eyebrow: '',
       title: 'Leandro Damasio',
       lead: 'Computer Engineer. AI systems and interfaces for high-reliability environments.',
       body: 'Builds digital products, automation platforms and operational systems with institutional rigor. The emphasis is reliability, observability and operational clarity.',

--- a/lda-front/src/routes/+page.server.ts
+++ b/lda-front/src/routes/+page.server.ts
@@ -7,7 +7,7 @@ export const load: PageServerLoad = async ({ url }) => {
   const locale = resolveLocale(url.hostname);
   return {
     locale,
-    copy: getHomeCopy(locale),
+    copy: await getHomeCopy(locale),
     notes: (await getAllNotes(locale)).slice(0, 4).map((note) => ({ ...note, dateLabel: formatNoteDate(note.date) })),
     alternateHref: getLocaleHref(locale, `${url.pathname}${url.search}`),
   };

--- a/lda-front/src/routes/+page.svelte
+++ b/lda-front/src/routes/+page.svelte
@@ -23,7 +23,7 @@
     <div class="brand">
       <span class="brand-mark">LD</span>
       <div>
-        <p class="eyebrow">{data.copy.hero.eyebrow}</p>
+        {#if data.copy.hero.eyebrow}<p class="eyebrow">{data.copy.hero.eyebrow}</p>{/if}
         <p class="brand-subline">{data.copy.hero.location}</p>
       </div>
     </div>

--- a/lda-front/src/routes/+page.svelte
+++ b/lda-front/src/routes/+page.svelte
@@ -63,6 +63,14 @@
       </aside>
     </section>
 
+    <section class="content-section">
+      <div class="section-heading section-heading-wide">
+        <p class="eyebrow">{data.copy.team.eyebrow}</p>
+        <h2>{data.copy.team.title}</h2>
+      </div>
+      <p class="body">{data.copy.team.body}</p>
+    </section>
+
     <section id="work" class="content-section">
       <div class="section-heading section-heading-wide">
         <p class="eyebrow">{data.copy.work.selectedProjects}</p>

--- a/lda-front/src/routes/blog/+page.server.ts
+++ b/lda-front/src/routes/blog/+page.server.ts
@@ -7,7 +7,7 @@ export const load: PageServerLoad = async ({ url }) => {
   const locale = resolveLocale(url.hostname);
   return {
     locale,
-    copy: getHomeCopy(locale),
+    copy: await getHomeCopy(locale),
     notes: (await getAllNotes(locale)).map((note) => ({ ...note, dateLabel: formatNoteDate(note.date) })),
     alternateHref: getLocaleHref(locale, `${url.pathname}${url.search}`),
   };

--- a/lda-front/src/routes/blog/[slug]/+page.server.ts
+++ b/lda-front/src/routes/blog/[slug]/+page.server.ts
@@ -14,7 +14,7 @@ export const load: PageServerLoad = async ({ params, url }) => {
 
   return {
     locale,
-    copy: getHomeCopy(locale),
+    copy: await getHomeCopy(locale),
     note: {
       ...note,
       dateLabel: formatNoteDate(note.date),


### PR DESCRIPTION
## What changed
- Added an automated CMS publication flow for the home translation bundles and legacy translation archive.
- Switched the frontend to read private Contabo S3 objects with signed requests on the server side.
- Published the current bundles into CMS/S3:
  - `site/pt-BR/translations-home/index.md`
  - `site/en/translations-home/index.md`
  - `site/pt-BR/translations-legacy/index.md`
  - `site/en/translations-legacy/index.md`

## Why
- The legacy Next translation bundles needed a clean migration path into the SvelteKit runtime without public bucket exposure.
- The frontend already had private S3 credentials in deployment; the loader now uses them correctly.

## Validation
- `npm run check`
- `npm run build`
- Local preview render for home and blog with private bundle reads